### PR TITLE
More mock classes and methods missing for Elasticsearch 6

### DIFF
--- a/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -42,6 +42,14 @@ public class LoggerContext {
             public Map<String, LoggerConfig> getLoggers() {
                 return Collections.emptyMap();
             }
+
+            @Override
+            public LoggerConfig getLoggerConfig(String name) {
+                return new LoggerConfig();
+            }
         };
+    }
+
+    public void updateLoggers() {
     }
 }

--- a/src/main/java/org/apache/logging/log4j/core/config/Configuration.java
+++ b/src/main/java/org/apache/logging/log4j/core/config/Configuration.java
@@ -19,5 +19,7 @@ import java.util.Map;
 
 public interface Configuration {
 
-    public Map<String, LoggerConfig> getLoggers();
+    Map<String, LoggerConfig> getLoggers();
+
+    LoggerConfig getLoggerConfig(String name);
 }

--- a/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -15,5 +15,10 @@
  */
 package org.apache.logging.log4j.core.config;
 
+import org.apache.logging.log4j.Level;
+
 public class LoggerConfig {
+
+    public void setLevel(final Level level) {
+    }
 }

--- a/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationFactory.java
+++ b/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationFactory.java
@@ -1,0 +1,4 @@
+package org.apache.logging.log4j.core.config.properties;
+
+public class PropertiesConfigurationFactory {
+}

--- a/src/main/java/org/apache/logging/log4j/core/pattern/LogEventPatternConverter.java
+++ b/src/main/java/org/apache/logging/log4j/core/pattern/LogEventPatternConverter.java
@@ -1,0 +1,4 @@
+package org.apache.logging.log4j.core.pattern;
+
+public class LogEventPatternConverter {
+}


### PR DESCRIPTION
New classes were needed for running Spring Data Elasticsearch 3.2.
I've also added missing methods requested in #1